### PR TITLE
fix case issue in requires

### DIFF
--- a/source/Connection.js
+++ b/source/Connection.js
@@ -1,4 +1,4 @@
-var utility = require('./utility/Utility.js'),
+var utility = require('./utility/utility.js'),
     ConnectionEvents = require('./connection/ConnectionEvents.js'),
     ConnectionStreams = require('./connection/ConnectionStreams.js'),
     ConnectionProfile = require('./connection/ConnectionProfile.js'),

--- a/source/auth/Auth-browser.js
+++ b/source/auth/Auth-browser.js
@@ -1,6 +1,6 @@
 /* global confirm, document, navigator, location, window */
 
-var utility = require('../utility/Utility.js');
+var utility = require('../utility/utility.js');
 var Connection = require('../Connection.js');
 var _ = require('underscore');
 

--- a/source/auth/Auth.js
+++ b/source/auth/Auth.js
@@ -1,4 +1,4 @@
-var utility = require('../utility/Utility.js');
+var utility = require('../utility/utility.js');
 
 module.exports =  utility.isBrowser() ?
     require('./Auth-browser.js') : require('./Auth-node.js');

--- a/source/connection/ConnectionEvents.js
+++ b/source/connection/ConnectionEvents.js
@@ -1,4 +1,4 @@
-var utility = require('../utility/Utility.js'),
+var utility = require('../utility/utility.js'),
   _ = require('underscore'),
   Filter = require('../Filter'),
   Event = require('../Event'),

--- a/source/connection/ConnectionStreams.js
+++ b/source/connection/ConnectionStreams.js
@@ -1,5 +1,5 @@
 var _ = require('underscore'),
-  utility = require('../utility/Utility.js'),
+  utility = require('../utility/utility.js'),
   Stream = require('../Stream.js'),
   CC = require('./ConnectionConstants.js');
 

--- a/source/main.js
+++ b/source/main.js
@@ -7,7 +7,7 @@ module.exports = {
   Filter: require('./Filter.js'),
 
   eventTypes: require('./eventTypes.js'),
-  utility: require('./utility/Utility.js'),
+  utility: require('./utility/utility.js'),
   MESSAGES: {
     MONITOR: require('./Monitor.js').Messages
   }


### PR DESCRIPTION
I've encountered an error while trying to run a simple test program on my OS (BLinux - old modified OpenSuse).
Some of the requires made in several files were trying to access the 'Utility.js' file which is actually named 'utility.js'.
The lack of upper character on the first letter caused node to print an error, stating it could not find the file.
Changing the character in the few files that contain the incorrect requires fix this problem. 