### PR TITLE
fix mocha in devDependencies and a test for accesses

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
     "underscore": "latest"
   },
   "devDependencies": {
-    "coffee-script": "latest",
     "async": "latest",
     "blanket": "latest",
+    "coffee-script": "latest",
     "grunt": "latest",
     "grunt-browserify": "latest",
     "grunt-contrib-copy": "latest",
@@ -57,6 +57,7 @@
     "grunt-jsdoc": "latest",
     "grunt-mocha-test": "latest",
     "grunt-shell": "latest",
+    "mocha": "latest",
     "nock": "latest",
     "replay": "latest",
     "should": "latest"

--- a/test/acceptance/node/Connection.accesses.test.js
+++ b/test/acceptance/node/Connection.accesses.test.js
@@ -7,11 +7,10 @@ var Pryv = require('../../../source/main'),
 describe('Connection.accesses', function () {
   this.timeout(10000);
 
-  var accessConnection, streamConnection;
+  var accessConnection;
 
 
   before(function (done) {
-    streamConnection = new Pryv.Connection(config.connectionSettings);
     Pryv.Connection.login(config.loginParams, function (err, newConnection) {
       accessConnection = newConnection;
       done(err);
@@ -20,7 +19,7 @@ describe('Connection.accesses', function () {
 
   describe('get()', function () {
     it('must return the list of connection accesses', function (done) {
-      streamConnection.accesses.get(function (err, res) {
+      accessConnection.accesses.get(function (err, res) {
         should.not.exist(err);
         should.exist(res);
         res.should.be.instanceOf(Array);


### PR DESCRIPTION
- npm install triggers an error, adding `mocha: "latest"` in devDependencies in the package.json fix it.

- useless use of Pryv.Connection constructor in test suite.