### PR TITLE
add condition in connectionStreams GET

### DIFF
--- a/source/connection/ConnectionStreams.js
+++ b/source/connection/ConnectionStreams.js
@@ -43,6 +43,8 @@ ConnectionStreams.prototype.get = function (options, callback) {
     var resultTree = [];
     if (options && _.has(options, 'parentId')) {
       resultTree = this.connection.datastore.getStreamById(options.parentId).children;
+    } else if (options && _.has(options, 'state')) {
+      resultTree = this.connection.datastore.getStreams(options.state);
     } else {
       resultTree = this.connection.datastore.getStreams();
     }

--- a/test/acceptance/node/Connection.events.test.js
+++ b/test/acceptance/node/Connection.events.test.js
@@ -3,8 +3,7 @@ var Pryv = require('../../../source/main'),
   should = require('should'),
   config = require('../test-support/config.js'),
   async = require('async'),
-  fs = require('fs'),
-  _ = require('lodash');
+  fs = require('fs');
 
 
 describe('Connection.events', function () {
@@ -81,7 +80,7 @@ describe('Connection.events', function () {
         function (stepDone) {
           connection.events.delete(eventDeleted, function (err) {
             stepDone(err);
-        });
+          });
         }
       ], done);
     });
@@ -121,7 +120,7 @@ describe('Connection.events', function () {
         should.not.exist(err);
         should.exist(events.eventDeletions);
         var found = false;
-        _.forEach(events.eventDeletions, function (deletedEvent) {
+        events.eventDeletions.forEach(function (deletedEvent) {
           if (deletedEvent.id === deletedEventId) {
             found = true;
           }

--- a/test/acceptance/node/Connection.streams.test.js
+++ b/test/acceptance/node/Connection.streams.test.js
@@ -29,12 +29,10 @@ describe('Connection.streams', function () {
         };
       async.series([
         function (stepDone) {
-          var stream = new Pryv.Stream(connection, streamData);
-          connection.streams.create(stream, stepDone);
+          connection.streams.create(new Pryv.Stream(connection, streamData), stepDone);
         },
         function (stepDone) {
-          var stream = new Pryv.Stream(connection, streamDelete);
-          connection.streams.create(stream, stepDone);
+          connection.streams.create(new Pryv.Stream(connection, streamDelete), stepDone);
         },
         function (stepDone) {
           testTimeStart = new Date().getTime() / 1000;

--- a/test/acceptance/node/Connection.test.js
+++ b/test/acceptance/node/Connection.test.js
@@ -1,6 +1,7 @@
 /* global describe, it */
 var Pryv = require('../../../source/main'),
   should = require('should'),
+  _ = require('underscore'),
   config = require('../test-support/config.js');
 
 describe('Connection', function () {
@@ -88,13 +89,7 @@ describe('Connection', function () {
     });
 
     it('must return an error when the credentials are invalid', function (done) {
-      var errorParams = {
-        username: config.loginParams.username,
-        password: config.loginParams.password,
-        appId: config.loginParams.appId,
-        domain: config.loginParams.domain,
-        origin: config.loginParams.origin
-      };
+      var errorParams = _.clone(config.loginParams);
       errorParams.password = 'falsePassword';
       Pryv.Connection.login(errorParams, function (err) {
         should.exist(err);

--- a/test/acceptance/node/Connection.test.js
+++ b/test/acceptance/node/Connection.test.js
@@ -1,8 +1,7 @@
 /* global describe, it */
 var Pryv = require('../../../source/main'),
   should = require('should'),
-  config = require('../test-support/config.js'),
-  _ = require('lodash');
+  config = require('../test-support/config.js');
 
 describe('Connection', function () {
   this.timeout(10000);
@@ -89,7 +88,13 @@ describe('Connection', function () {
     });
 
     it('must return an error when the credentials are invalid', function (done) {
-      var errorParams = _.clone(config.loginParams);
+      var errorParams = {
+        username: config.loginParams.username,
+        password: config.loginParams.password,
+        appId: config.loginParams.appId,
+        domain: config.loginParams.domain,
+        origin: config.loginParams.origin
+      };
       errorParams.password = 'falsePassword';
       Pryv.Connection.login(errorParams, function (err) {
         should.exist(err);

--- a/test/acceptance/test-support/config.js
+++ b/test/acceptance/test-support/config.js
@@ -14,5 +14,6 @@ module.exports.loginParams = {
 };
 
 module.exports.testDiaryStreamId = 'diary';
+module.exports.testDeletedStreamId = 'deleted';
 module.exports.testActivityStreamId = 'activity';
 module.exports.testNoChildStreamId = 'nochildstream';


### PR DESCRIPTION
## Unused parameter in streams.get method

ConnectionStreams.get doesn't take into account the 'state' argument.

Therefore the [Getting started: Javascript about stream.get](http://api.pryv.com/getting-started/javascript/#manage-streams) is false. The 'option.state' argument doesn't have any effect.

Adding a condition in the ConnectionStreams.get function fix this issue.

## Test wouldn't run (error: Mocha exploded)

This error is trigger because module 'lodash' is used twice by doesn't appear in package.json.

He was used twice: in Connection.events.test.js and in Connection.test.js.
Since his uses were unnecessary (overkill), I removed and replaced them by other methods.

## Add test in Connection.streams.test.js

The test for the fix of the state argument in ConnectionStreams.get.