### PR TITLE
fix callback usage of Connection.login

### DIFF
--- a/source/auth/Auth-browser.js
+++ b/source/auth/Auth-browser.js
@@ -399,7 +399,7 @@ Auth.prototype.login = function (settings) {
   });
 
   Connection.login(settings, function(err, conn, res) {
-    if((err || !res.token) && typeof(this.settings.callbacks.error) === 'function') {
+    if((err || !conn) && typeof(this.settings.callbacks.error) === 'function') {
       return this.settings.callbacks.error(err || res);
     }
 


### PR DESCRIPTION
Auth-browser now tests correctly for an error in the login phase.