### PR TITLE
events.getAttachment: manage error case & clean code

### DIFF
--- a/source/connection/ConnectionEvents.js
+++ b/source/connection/ConnectionEvents.js
@@ -374,11 +374,15 @@ ConnectionEvents.prototype.getAttachment =
     if (typeof(callback) !== 'function') {
       throw new Error(CC.Errors.CALLBACK_IS_NOT_A_FUNCTION);
     }
+    if (utility.isBrowser()) {
+      return callback(new Error('Function not implemented for browser, only available in NodeJS.'));
+    }
     this.connection.request({
       method: 'GET',
       path: '/events/' + params.eventId + '/' + params.fileId,
       progressCallback: progressCallback,
       parseResult: 'binary',
+
       callback: function (err, result) {
         if (err) {
           return callback(err);

--- a/source/utility/request-node.js
+++ b/source/utility/request-node.js
@@ -60,8 +60,9 @@ module.exports = function (pack) {
       headers: res.headers
     };
 
-    if (parseResult !== 'binary' || (parseResult === 'binary' &&
+    if (parseResult === 'json' || (parseResult === 'binary' &&
       (res.statusCode < 200 || res.statusCode >= 300))) {
+      // We load the full response body and parse the JSON
       var bodyarr = [];
       res.on('data', function (chunk) {
         bodyarr.push(chunk);
@@ -76,9 +77,9 @@ module.exports = function (pack) {
           return pack.error('request failed to parse JSON in response' +
             bodyarr.join('') + '\n' + HttpRequestDetails, responseInfo);
         }
-
         return pack.success(data, responseInfo);
       });
+
     } else { // binary response body without errors, we return a readable stream
       return pack.success(res, responseInfo);
     }

--- a/source/utility/request-node.js
+++ b/source/utility/request-node.js
@@ -75,7 +75,7 @@ module.exports = function (pack) {
           bodyarr.join('') + '\n' + HttpRequestDetails, responseInfo);
         }
       } else if (parseResult === 'binary') {
-        data = res;
+        data = Buffer.concat(bodyarr);
       }
       return pack.success(data, responseInfo);
     });

--- a/source/utility/request-node.js
+++ b/source/utility/request-node.js
@@ -54,9 +54,7 @@ module.exports = function (pack) {
     }
   }
 
-  var req;
-
-  req = http.request(httpOptions, function (res) {
+  var req = http.request(httpOptions, function (res) {
     var responseInfo = {
       code: res.statusCode,
       headers: res.headers
@@ -81,7 +79,7 @@ module.exports = function (pack) {
 
         return pack.success(data, responseInfo);
       });
-    } else {
+    } else { // binary response body without errors, we return a readable stream
       return pack.success(res, responseInfo);
     }
   });

--- a/test/acceptance/node/Connection.events.test.js
+++ b/test/acceptance/node/Connection.events.test.js
@@ -796,7 +796,6 @@ describe('Connection.events', function () {
     });
   });
 
-  // TODO see if useful or not, since the URL is used directly to get an Attachment content
   describe('getAttachment()', function () {
 
     var event, formData, attachment, originalFile;
@@ -816,10 +815,6 @@ describe('Connection.events', function () {
         filename: filename
       });
 
-      event = {
-        streamId: testStream.id,
-        type: 'picture/attached'
-      };
       async.series([
         function (stepDone) {
           connection.events.create(event, function (err, newEvent) {

--- a/test/acceptance/node/Connection.events.test.js
+++ b/test/acceptance/node/Connection.events.test.js
@@ -796,11 +796,11 @@ describe('Connection.events', function () {
   // TODO see if useful or not, since the URL is used directly to get an Attachment content
   describe('getAttachment()', function () {
 
-    var event, formData, attachment, data;
+    var event, formData, attachment, data, originalFile;
 
     before(function (done) {
-      var pictureData = fs.readFileSync(__dirname + '/../test-support/photo.PNG');
-      should.exist(pictureData);
+      originalFile = fs.readFileSync(__dirname + '/../test-support/photo.PNG');
+      should.exist(originalFile);
 
       event = {
         streamId: testStream.id, type: 'picture/attached',
@@ -808,7 +808,7 @@ describe('Connection.events', function () {
       };
       var filename = 'testGetAttachmentPicture';
 
-      formData = Pryv.utility.forgeFormData('attachment0', pictureData, {
+      formData = Pryv.utility.forgeFormData('attachment0', originalFile, {
         type: 'image/png',
         filename: filename
       });
@@ -863,14 +863,7 @@ describe('Connection.events', function () {
           connection.events.getAttachment(pack, function (err, res) {
             should.not.exist(err);
             should.exist(res);
-            data = res;
-            stepDone();
-          });
-        },
-        function (stepDone) {
-          fs.writeFile(testFileName, data, function (err) {
-            should.not.exist(err);
-
+            should.equal(Buffer.compare(originalFile,res), 0);
             stepDone();
           });
         }

--- a/test/acceptance/node/Connection.events.test.js
+++ b/test/acceptance/node/Connection.events.test.js
@@ -18,8 +18,11 @@ describe('Connection.events', function () {
     };
     connection = new Pryv.Connection(config.connectionSettings);
     connection.streams.create(testStream, function (err, newStream) {
+      if (err) {
+        return done(err);
+      }
       testStream = newStream;
-      done(err);
+      done();
     });
   });
 

--- a/test/acceptance/node/Connection.events.test.js
+++ b/test/acceptance/node/Connection.events.test.js
@@ -799,7 +799,7 @@ describe('Connection.events', function () {
   // TODO see if useful or not, since the URL is used directly to get an Attachment content
   describe('getAttachment()', function () {
 
-    var event, formData, attachment, data, originalFile;
+    var event, formData, attachment, originalFile;
 
     before(function (done) {
       originalFile = fs.readFileSync(__dirname + '/../test-support/photo.PNG');
@@ -860,7 +860,6 @@ describe('Connection.events', function () {
       pack.readToken = attachment.readToken;
       pack.fileId = attachment.id;
       pack.eventId = event.id;
-      var testFileName = 'test-delete_me_please.PNG';
       async.series([
         function (stepDone) {
           connection.events.getAttachment(pack, function (err, res) {

--- a/test/acceptance/test-support/config.js
+++ b/test/acceptance/test-support/config.js
@@ -1,7 +1,7 @@
 
 module.exports.connectionSettings = {
   username: 'testuser',
-  auth: 'cj7fy7c5z00030cqvhfiwgp5l',
+  auth: 'cjamze7u104mq0cp9i39e7gsn',
   domain: 'pryv.li'
 };
 


### PR DESCRIPTION
Actually fixes the test for `connection.events.getAttachment()`.

Currently the function's callback returns the [HTTPresponse](https://nodejs.org/api/http.html#http_class_http_incomingmessage) which has a readableStream interface. 

## Questions

### streamed response
It would be better to return strictly the readable stream and not the additional properties.  

### error handling
The handling of the response is different in case there is an error, the response body is JSON containing the error details, which is a different handling that can be differentiated by HTTP status.
- Is it OK to filter out all statuses outside the 2xx range? Or should we include the 3xx as well?
- The request-node code is messy

