### PR TITLE
Fix deprecated calls to Connection(username, auth, settings)

### DIFF
--- a/examples/browser/basics.html
+++ b/examples/browser/basics.html
@@ -24,7 +24,7 @@
     var $events = document.getElementById('events');
 
     // .useStaging() only when debug / dev
-    var api = new pryv.Connection('perkikiki', 'TTZycvBTiq', {staging: true});
+    var api = new pryv.Connection({username: 'perkikiki', auth: 'TTZycvBTiq', staging: true});
 
     api.accessInfo(function(error, infos) {
       $accessInfo.value = JSON.stringify(infos, null, 2);

--- a/source/auth/Auth-browser.js
+++ b/source/auth/Auth-browser.js
@@ -111,7 +111,11 @@ Auth.prototype.setup = function (settings) {
 
   this.stateInitialization();
 
-  this.connection = new Connection(null, null, {ssl: true, domain: this.settings.domain});
+  this.connection = new Connection({
+    username: null,
+    auth: null,
+    ssl: true,
+    domain: this.settings.domain});
   // Look if we have a returning user (document.cookie)
   var cookieUserName = this.cookieEnabled ?
     utility.docCookies.getItem('access_username' + this.settings.domain) : false;
@@ -485,7 +489,9 @@ Auth.prototype.whoAmI = function (settings) {
       if (data.token) {
         this.connection.username = data.username;
         this.connection.auth = data.token;
-        var conn = new Connection(data.username, data.token, {
+        var conn = new Connection({
+          username: data.username,
+          auth: data.token,
           ssl: settings.ssl,
           domain: settings.domain
         });


### PR DESCRIPTION
As per [1], `Connection(username, auth, settings)` is deprecated. Replacing
remaining old format calls in the project with the correct form. No more
annoying warning message in the console log when developping ;)

[1] https://github.com/pryv/lib-javascript/blob/2d9ad9e6664676d0d908b2992369a21c9b8e956b/source/Connection.js#L37-L38